### PR TITLE
Add 1% down threshold for PR coverage.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,6 @@
 coverage:
   range: "60...80"
+  status:
+    patch:
+      default:
+        threshold: 1


### PR DESCRIPTION
Note: It wouldn't decrease project coverage in the future, as we have `project.threshold` to check summary coverage