### PR TITLE
Fix panic in MySQL slowlog parser.

### DIFF
--- a/agents/mysql/slowlog/slowlog.go
+++ b/agents/mysql/slowlog/slowlog.go
@@ -303,6 +303,10 @@ func makeBuckets(agentID string, res event.Result, periodStart time.Time, period
 	buckets := make([]*agentpb.MetricsBucket, 0, len(res.Class))
 
 	for _, v := range res.Class {
+		if v.Metrics == nil {
+			continue
+		}
+
 		mb := &agentpb.MetricsBucket{
 			Common: &agentpb.MetricsBucket_Common{
 				Queryid:              v.Id,
@@ -315,14 +319,16 @@ func makeBuckets(agentID string, res event.Result, periodStart time.Time, period
 				AgentType:            inventorypb.AgentType_QAN_MYSQL_SLOWLOG_AGENT,
 				PeriodStartUnixSecs:  uint32(periodStart.Unix()),
 				PeriodLengthSecs:     periodLengthSecs,
-				Example:              v.Example.Query,
-				ExampleFormat:        agentpb.ExampleFormat_EXAMPLE,
-				ExampleType:          agentpb.ExampleType_RANDOM,
 				NumQueries:           float32(v.TotalQueries),
 				Errors:               errListsToMap(v.ErrorsCode, v.ErrorsCount),
 				NumQueriesWithErrors: v.NumQueriesWithErrors,
 			},
 			Mysql: &agentpb.MetricsBucket_MySQL{},
+		}
+		if v.Example != nil {
+			mb.Common.Example = v.Example.Query
+			mb.Common.ExampleFormat = agentpb.ExampleFormat_EXAMPLE
+			mb.Common.ExampleType = agentpb.ExampleType_RANDOM
 		}
 
 		// If key has suffix _time or _wait than field is TimeMetrics.


### PR DESCRIPTION
https://travis-ci.com/percona/pmm-agent/jobs/230158555

```
time="2019-09-02T18:44:55Z" level=info msg="Processing file /home/travis/gopath/src/github.com/percona/pmm-agent/testdata/slowlogs/slow.log." test=TestSlowLog/Normal
time="2019-09-02T18:44:55Z" level=info msg="Processing file /slowlogs/slow.log." test=TestSlowLog/NoFile
time="2019-09-02T18:44:55Z" level=error msg="Failed to start reader for file /slowlogs/slow.log: open /slowlogs/slow.log: no such file or directory." test=TestSlowLog/NoFile
time="2019-09-02T18:44:56Z" level=info msg="Processing file /slowlogs/slow.log." test=TestSlowLog/NoFile
time="2019-09-02T18:44:56Z" level=error msg="Failed to start reader for file /slowlogs/slow.log: open /slowlogs/slow.log: no such file or directory." test=TestSlowLog/NoFile
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xd13415]

goroutine 31 [running]:
github.com/percona/pmm-agent/agents/mysql/slowlog.makeBuckets(0x0, 0x0, 0xc0001c2360, 0xc00017e7e0, 0x0, 0x0, 0x0, 0xbf5376a9ef713032, 0x212e55e, 0x160a620, ...)
	/home/travis/gopath/src/github.com/percona/pmm-agent/agents/mysql/slowlog/slowlog.go:318 +0x6b5
github.com/percona/pmm-agent/agents/mysql/slowlog.(*SlowLog).processFile(0xc000186100, 0xfcc420, 0xc000186280, 0xc0001be320, 0x4f, 0x0, 0x0, 0x0)
	/home/travis/gopath/src/github.com/percona/pmm-agent/agents/mysql/slowlog/slowlog.go:286 +0x11a5
github.com/percona/pmm-agent/agents/mysql/slowlog.(*SlowLog).Run.func3(0xc000186100, 0xc0001be320, 0x4f, 0xc0001726c0, 0xfcc420, 0xc000186280, 0x0)
	/home/travis/gopath/src/github.com/percona/pmm-agent/agents/mysql/slowlog/slowlog.go:136 +0x126
created by github.com/percona/pmm-agent/agents/mysql/slowlog.(*SlowLog).Run
	/home/travis/gopath/src/github.com/percona/pmm-agent/agents/mysql/slowlog/slowlog.go:134 +0x2f7
FAIL	github.com/percona/pmm-agent/agents/mysql/slowlog	4.257s
```