### PR TITLE
Enable debug/trace logging with PMM_DEBUG/TRACE.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/percona/pmm/utils/nodeinfo"
@@ -212,6 +213,14 @@ func get(args []string, l *logrus.Entry) (cfg *Config, configFileF string, err e
 				cfg.Server.Address = net.JoinHostPort(host, "443")
 				l.Infof("Updating PMM Server address from %q to %q.", host, cfg.Server.Address)
 			}
+		}
+
+		// enabled cross-component PMM_DEBUG and PMM_TRACE take priority
+		if b, _ := strconv.ParseBool(os.Getenv("PMM_DEBUG")); b {
+			cfg.Debug = true
+		}
+		if b, _ := strconv.ParseBool(os.Getenv("PMM_TRACE")); b {
+			cfg.Trace = true
 		}
 	}()
 


### PR DESCRIPTION
Those environment variables enable debug/trace logging in all PMM
components. That's mostly useful for PMM Server in Docker:
$ docker run -e PMM_DEBUG=1 ...