### PR TITLE
PMM-6336 Fix Disable query example for Perf Schema.

### DIFF
--- a/actions/postgresql_query_show_action_test.go
+++ b/actions/postgresql_query_show_action_test.go
@@ -46,7 +46,7 @@ func TestPostgreSQLQueryShow(t *testing.T) {
 		b, err := a.Run(ctx)
 		require.NoError(t, err)
 		assert.LessOrEqual(t, 22150, len(b))
-		assert.LessOrEqual(t, len(b), 29156)
+		assert.LessOrEqual(t, len(b), 29184)
 
 		data, err := agentpb.UnmarshalActionQueryResult(b)
 		require.NoError(t, err)

--- a/agents/mysql/perfschema/perfschema.go
+++ b/agents/mysql/perfschema/perfschema.go
@@ -77,10 +77,10 @@ func New(params *Params, l *logrus.Entry) (*PerfSchema, error) {
 	reformL := sqlmetrics.NewReform("mysql", params.AgentID, l.Tracef)
 	// TODO register reformL metrics https://jira.percona.com/browse/PMM-4087
 	q := reform.NewDB(sqlDB, mysql.Dialect, reformL).WithTag(queryTag)
-	return newPerfSchema(q, sqlDB, params.AgentID, l, params.DisableQueryExamples), nil
+	return newPerfSchema(q, sqlDB, params.AgentID, params.DisableQueryExamples, l), nil
 }
 
-func newPerfSchema(q *reform.Querier, dbCloser io.Closer, agentID string, l *logrus.Entry, disableQueryExamples bool) *PerfSchema {
+func newPerfSchema(q *reform.Querier, dbCloser io.Closer, agentID string, disableQueryExamples bool, l *logrus.Entry) *PerfSchema {
 	return &PerfSchema{
 		q:                    q,
 		dbCloser:             dbCloser,

--- a/agents/mysql/perfschema/perfschema.go
+++ b/agents/mysql/perfschema/perfschema.go
@@ -77,18 +77,19 @@ func New(params *Params, l *logrus.Entry) (*PerfSchema, error) {
 	reformL := sqlmetrics.NewReform("mysql", params.AgentID, l.Tracef)
 	// TODO register reformL metrics https://jira.percona.com/browse/PMM-4087
 	q := reform.NewDB(sqlDB, mysql.Dialect, reformL).WithTag(queryTag)
-	return newPerfSchema(q, sqlDB, params.AgentID, l), nil
+	return newPerfSchema(q, sqlDB, params.AgentID, l, params.DisableQueryExamples), nil
 }
 
-func newPerfSchema(q *reform.Querier, dbCloser io.Closer, agentID string, l *logrus.Entry) *PerfSchema {
+func newPerfSchema(q *reform.Querier, dbCloser io.Closer, agentID string, l *logrus.Entry, disableQueryExamples bool) *PerfSchema {
 	return &PerfSchema{
-		q:            q,
-		dbCloser:     dbCloser,
-		agentID:      agentID,
-		l:            l,
-		changes:      make(chan agents.Change, 10),
-		historyCache: newHistoryCache(retainHistory),
-		summaryCache: newSummaryCache(retainSummaries),
+		q:                    q,
+		dbCloser:             dbCloser,
+		agentID:              agentID,
+		disableQueryExamples: disableQueryExamples,
+		l:                    l,
+		changes:              make(chan agents.Change, 10),
+		historyCache:         newHistoryCache(retainHistory),
+		summaryCache:         newSummaryCache(retainSummaries),
 	}
 }
 

--- a/agents/mysql/perfschema/perfschema.go
+++ b/agents/mysql/perfschema/perfschema.go
@@ -63,8 +63,8 @@ type Params struct {
 	DisableQueryExamples bool
 }
 
-// NewPerfSchemaParams holds all required parameters to instantiate a new PerfSchema
-type NewPerfSchemaParams struct {
+// newPerfSchemaParams holds all required parameters to instantiate a new PerfSchema
+type newPerfSchemaParams struct {
 	Querier              *reform.Querier
 	DBCloser             io.Closer
 	AgentID              string
@@ -87,7 +87,7 @@ func New(params *Params, l *logrus.Entry) (*PerfSchema, error) {
 	// TODO register reformL metrics https://jira.percona.com/browse/PMM-4087
 	q := reform.NewDB(sqlDB, mysql.Dialect, reformL).WithTag(queryTag)
 
-	newParams := &NewPerfSchemaParams{
+	newParams := &newPerfSchemaParams{
 		Querier:              q,
 		DBCloser:             sqlDB,
 		AgentID:              params.AgentID,
@@ -98,7 +98,7 @@ func New(params *Params, l *logrus.Entry) (*PerfSchema, error) {
 
 }
 
-func newPerfSchema(params *NewPerfSchemaParams) *PerfSchema {
+func newPerfSchema(params *newPerfSchemaParams) *PerfSchema {
 	return &PerfSchema{
 		q:                    params.Querier,
 		dbCloser:             params.DBCloser,

--- a/agents/mysql/perfschema/perfschema_test.go
+++ b/agents/mysql/perfschema/perfschema_test.go
@@ -179,7 +179,7 @@ func setup(t *testing.T, db *reform.DB, disableQueryExamples bool) *PerfSchema {
 	_, err = db.Exec(truncateQuery + "performance_schema.events_statements_summary_by_digest")
 	require.NoError(t, err)
 
-	newParams := &NewPerfSchemaParams{
+	newParams := &newPerfSchemaParams{
 		Querier:              db.WithTag(queryTag),
 		DBCloser:             nil,
 		AgentID:              "agent_id",
@@ -477,6 +477,7 @@ func TestPerfSchema(t *testing.T) {
 		buckets, err := m.getNewBuckets(time.Date(2019, 4, 1, 10, 59, 0, 0, time.UTC), 60)
 		require.NoError(t, err)
 
+		require.NotEmpty(t, buckets)
 		for _, b := range buckets {
 			assert.NotEmpty(t, b.Common.Queryid)
 			assert.NotEmpty(t, b.Common.Fingerprint)

--- a/agents/mysql/perfschema/perfschema_test.go
+++ b/agents/mysql/perfschema/perfschema_test.go
@@ -309,7 +309,7 @@ func TestPerfSchema(t *testing.T) {
 	}
 
 	t.Run("Sleep", func(t *testing.T) {
-		m := setup(t, db, disableQueryExamples)
+		m := setup(t, db, enableQueryExamples)
 
 		_, err := db.Exec("SELECT /* Sleep */ sleep(0.1)")
 		require.NoError(t, err)

--- a/agents/mysql/perfschema/perfschema_test.go
+++ b/agents/mysql/perfschema/perfschema_test.go
@@ -174,7 +174,7 @@ func setup(t *testing.T, db *reform.DB, disableQueryExamples bool) *PerfSchema {
 	_, err = db.Exec(truncateQuery + "performance_schema.events_statements_summary_by_digest")
 	require.NoError(t, err)
 
-	p := newPerfSchema(db.WithTag(queryTag), nil, "agent_id", logrus.WithField("test", t.Name()), disableQueryExamples)
+	p := newPerfSchema(db.WithTag(queryTag), nil, "agent_id", disableQueryExamples, logrus.WithField("test", t.Name()))
 	require.NoError(t, p.refreshHistoryCache())
 	return p
 }

--- a/agents/mysql/perfschema/perfschema_test.go
+++ b/agents/mysql/perfschema/perfschema_test.go
@@ -479,7 +479,7 @@ func TestPerfSchema(t *testing.T) {
 	t.Run("DisableQueryExamples", func(t *testing.T) {
 		m := setup(t, &setupParams{
 			db:                   db,
-			disableQueryExamples: false,
+			disableQueryExamples: true,
 		})
 		_, err = db.Exec("SELECT 1, 2, 3, 4, id FROM city WHERE id = 1")
 		require.NoError(t, err)


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-6336

FB: https://github.com/Percona-Lab/pmm-submodules/pull/1029


With query example:

<img width="1900" alt="Screen Shot 2020-08-13 at 2 01 06 PM" src="https://user-images.githubusercontent.com/2538638/90230994-1f629f00-de23-11ea-93d0-419573ecd95a.png">


Without query example:

<img width="1900" alt="Screen Shot 2020-08-13 at 1 54 45 PM" src="https://user-images.githubusercontent.com/2538638/90231008-25588000-de23-11ea-8984-1654e3010766.png">
