### PR TITLE
PMM-5106 Adding Environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,12 @@ services:
       - PMM_DEBUG=1
       - PERCONA_TEST_CHECKS_INTERVAL=10s
       # for local development
-      - PERCONA_TEST_CHECKS_FILE=/srv/checks/custom-checks.yml
-      # for check-dev
-      # - PERCONA_TEST_SAAS_HOST=check-dev.percona.com:443
-      # - PERCONA_TEST_CHECKS_PUBLIC_KEY=RWTg+ZmCCjt7O8eWeAmTLAqW+1ozUbpRSKSwNTmO+exlS5KEIPYWuYdX
+      #- PERCONA_TEST_CHECKS_FILE=/srv/checks/custom-checks.yml
+      - ENABLE_ALERTING=1 
+      - ENABLE_BACKUP_MANAGEMENT=1  
+      - PERCONA_TEST_DBAAS=0
+      - PERCONA_TEST_SAAS_HOST=check-dev.percona.com:443
+      - PERCONA_TEST_CHECKS_PUBLIC_KEY=RWTg+ZmCCjt7O8eWeAmTLAqW+1ozUbpRSKSwNTmO+exlS5KEIPYWuYdX
     volumes:
       - ./testdata/checks:/srv/checks
 


### PR DESCRIPTION
Update Docker Compose to use same environment variables as we used with API tests setup for staging test instance. 