### PR TITLE
PMM-7917 pmm-agent high CPU usage for postgres

### DIFF
--- a/agents/postgres/pgstatstatements/pgstatstatements.go
+++ b/agents/postgres/pgstatstatements/pgstatstatements.go
@@ -235,6 +235,10 @@ func makeBuckets(current, prev map[int64]*pgStatStatementsExtended, l *logrus.En
 			l.Debugf("Normal query: %s.", currentPSS)
 		}
 
+		if len(currentPSS.Tables) == 0 {
+			currentPSS.Tables = extractTables(currentPSS.Query, l)
+		}
+
 		mb := &agentpb.MetricsBucket{
 			Common: &agentpb.MetricsBucket_Common{
 				Database:    currentPSS.Database,

--- a/agents/postgres/pgstatstatements/pgstatstatements_test.go
+++ b/agents/postgres/pgstatstatements/pgstatstatements_test.go
@@ -279,7 +279,7 @@ func TestPGStatStatementsQAN(t *testing.T) {
 			Common: &agentpb.MetricsBucket_Common{
 				Fingerprint:         selectAllCitiesLong,
 				Database:            "pmm-agent",
-				Tables:              []string{"city"},
+				Tables:              []string{},
 				Username:            "pmm-agent",
 				AgentId:             "agent_id",
 				PeriodStartUnixSecs: 1554116340,
@@ -322,7 +322,7 @@ func TestPGStatStatementsQAN(t *testing.T) {
 			Common: &agentpb.MetricsBucket_Common{
 				Fingerprint:         selectAllCitiesLong,
 				Database:            "pmm-agent",
-				Tables:              []string{"city"},
+				Tables:              []string{},
 				Username:            "pmm-agent",
 				AgentId:             "agent_id",
 				PeriodStartUnixSecs: 1554116340,

--- a/agents/postgres/pgstatstatements/stat_statements_cache.go
+++ b/agents/postgres/pgstatstatements/stat_statements_cache.go
@@ -93,7 +93,7 @@ func (ssc *statStatementCache) getStatStatementsExtended(ctx context.Context, q 
 	databases := queryDatabases(q)
 	usernames := queryUsernames(q)
 
-	rows, e := rowsByVersion(q, "WHERE queryid IS NOT NULL AND query IS NOT NULL LIMIT 100, 100")
+	rows, e := rowsByVersion(q, "WHERE queryid IS NOT NULL AND query IS NOT NULL")
 	if e != nil {
 		err = e
 		return

--- a/agents/postgres/pgstatstatements/stat_statements_cache.go
+++ b/agents/postgres/pgstatstatements/stat_statements_cache.go
@@ -93,11 +93,7 @@ func (ssc *statStatementCache) getStatStatementsExtended(ctx context.Context, q 
 	databases := queryDatabases(q)
 	usernames := queryUsernames(q)
 
-	// the same query can appear several times (with different database and/or username),
-	// so cache results of the current iteration too
-	tables := make(map[int64][]string)
-
-	rows, e := rowsByVersion(q, "WHERE queryid IS NOT NULL AND query IS NOT NULL")
+	rows, e := rowsByVersion(q, "WHERE queryid IS NOT NULL AND query IS NOT NULL LIMIT 100, 100")
 	if e != nil {
 		err = e
 		return
@@ -122,21 +118,13 @@ func (ssc *statStatementCache) getStatStatementsExtended(ctx context.Context, q 
 
 		if p := prev[c.QueryID]; p != nil {
 			oldN++
+			newSharedN++
 
-			// use previous values
 			c.Tables = p.Tables
 			c.Query, c.IsQueryTruncated = p.Query, p.IsQueryTruncated
 		} else {
 			newN++
 
-			// do not extract tables again if we saw this query during this iteration already
-			if tables[c.QueryID] == nil {
-				tables[c.QueryID] = extractTables(c.Query, ssc.l)
-			} else {
-				newSharedN++
-			}
-
-			c.Tables = tables[c.QueryID]
 			c.Query, c.IsQueryTruncated = truncate.Query(c.Query)
 		}
 
@@ -149,6 +137,7 @@ func (ssc *statStatementCache) getStatStatementsExtended(ctx context.Context, q 
 	if err != nil {
 		err = errors.Wrap(err, "failed to fetch pg_stat_statements")
 	}
+
 	return
 }
 

--- a/packages.dot
+++ b/packages.dot
@@ -4,8 +4,10 @@ digraph packages {
 	"/agents/mongodb" -> "/agents/mongodb/internal/profiler";
 	"/agents/mongodb" -> "/agents/mongodb/internal/report";
 	"/agents/mysql/perfschema" -> "/agents";
+	"/agents/mysql/perfschema" -> "/tlshelpers";
 	"/agents/mysql/slowlog" -> "/agents";
 	"/agents/mysql/slowlog" -> "/agents/mysql/slowlog/parser";
+	"/agents/mysql/slowlog" -> "/tlshelpers";
 	"/agents/noop" -> "/agents";
 	"/agents/postgres/pgstatmonitor" -> "/agents";
 	"/agents/postgres/pgstatstatements" -> "/agents";
@@ -29,4 +31,5 @@ digraph packages {
 	"/commands" -> "/config";
 	"/commands" -> "/connectionchecker";
 	"/connectionchecker" -> "/config";
+	"/connectionchecker" -> "/tlshelpers";
 }


### PR DESCRIPTION
When starting the agent or PostgreSQL connection comes back after a
disconnection, populating table names for the cache use too much CPU.