### PR TITLE
PMM-8952 pg_stat_monitor: trim asterisk in view names

### DIFF
--- a/agents/postgres/pgstatmonitor/models.go
+++ b/agents/postgres/pgstatmonitor/models.go
@@ -17,6 +17,7 @@ package pgstatmonitor
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/lib/pq"
@@ -230,6 +231,11 @@ func (m pgStatMonitor09) ToPgStatMonitor() (pgStatMonitor, error) {
 	bucketStartTime, err := time.Parse("2006-01-02 15:04:05", m.BucketStartTime)
 	if err != nil {
 		return pgStatMonitor{}, errors.Wrap(err, "cannot parse bucket start time")
+	}
+
+	// Views contain asterisk as a suffix so we need to trim them. Introduced in pg_stat_monitor 0.9.2.
+	for i, relation := range m.Relations {
+		m.Relations[i] = strings.TrimSuffix(relation, "*")
 	}
 
 	return pgStatMonitor{


### PR DESCRIPTION
pg_stat_monitor 0.9.2 beta1 introduced asterisk suffix for view names in relations column. Now, we trim it while reading from pg_stat_monitor.