### PR TITLE
PMM-7 provide a proper build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pmm-agent
 
-[![Build Status](https://travis-ci.com/percona/pmm-agent.svg?branch=main)](https://travis-ci.com/percona/pmm-agent)
+[![Build](https://github.com/percona/pmm-agent/actions/workflows/go.yml/badge.svg)](https://github.com/percona/pmm-agent/actions/workflows/go.yml)
 [![Code coverage](https://codecov.io/gh/percona/pmm-agent/branch/main/graph/badge.svg)](https://codecov.io/gh/percona/pmm-agent)
 [![Go Report Card](https://goreportcard.com/badge/github.com/percona/pmm-agent)](https://goreportcard.com/report/github.com/percona/pmm-agent)
 [![CLA assistant](https://cla-assistant.percona.com/readme/badge/percona/pmm-agent)](https://cla-assistant.percona.com/percona/pmm-agent)


### PR DESCRIPTION
Why: we have removed .travis, but did not update the badge.
Codecov was pointing to master, so I fixed that as well. It will start showing up a bit later.