### PR TITLE
PMM-7 revert default log level

### DIFF
--- a/config/logger.go
+++ b/config/logger.go
@@ -90,6 +90,6 @@ func parseLoggerConfig(level string, debug, trace bool) logrus.Level {
 		}
 	}
 
-	// warning level default by issue PMM-7326
-	return logrus.WarnLevel
+	// info level set by default, because we use info level to write logs of exporters.
+	return logrus.InfoLevel
 }


### PR DESCRIPTION
We use the info log level to print the output of exporters, so I have to revert this change to keep logs.

PMM-7, PMM-5668

Build: SUBMODULES-0

- [ ] Links to other linked pull requests (optional).
