### PR TITLE
PMM-9320: fix username/password incorrect escape

### DIFF
--- a/actions/mongodb_explain_action.go
+++ b/actions/mongodb_explain_action.go
@@ -18,17 +18,16 @@ package actions
 import (
 	"context"
 	"fmt"
+	"github.com/percona/pmm-agent/mongo_fix"
 	"path/filepath"
 	"strings"
 
 	"github.com/percona/percona-toolkit/src/go/mongolib/proto"
+	"github.com/percona/pmm-agent/utils/templates"
 	"github.com/percona/pmm/api/agentpb"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
-
-	"github.com/percona/pmm-agent/utils/templates"
 )
 
 type mongodbExplainAction struct {
@@ -68,7 +67,12 @@ func (a *mongodbExplainAction) Run(ctx context.Context) ([]byte, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(dsn))
+	opts, err := mongo_fix.ClientForDSN(dsn)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	client, err := mongo.Connect(ctx, opts)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/actions/mongodb_query_admincommand_action.go
+++ b/actions/mongodb_query_admincommand_action.go
@@ -20,13 +20,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/percona/pmm-agent/mongo_fix"
+	"github.com/percona/pmm-agent/utils/templates"
 	"github.com/percona/pmm/api/agentpb"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
-
-	"github.com/percona/pmm-agent/utils/templates"
 )
 
 // MongoDBQueryAdmincommandActionParams represent Mongo DB Query Admin Command Action params.
@@ -77,7 +76,12 @@ func (a *mongodbQueryAdmincommandAction) Run(ctx context.Context) ([]byte, error
 		return nil, errors.WithStack(err)
 	}
 
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(dsn))
+	opts, err := mongo_fix.ClientForDSN(dsn)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	client, err := mongo.Connect(ctx, opts)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/agents/mongodb/internal/profiler/collector/collector_test.go
+++ b/agents/mongodb/internal/profiler/collector/collector_test.go
@@ -18,6 +18,7 @@ package collector
 import (
 	"context"
 	"fmt"
+	"github.com/percona/pmm-agent/mongo_fix"
 	"strings"
 	"sync"
 	"testing"
@@ -30,7 +31,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
 
@@ -202,8 +202,12 @@ func createSession(dsn string, agentID string) (*mongo.Client, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), MgoTimeoutDialInfo)
 	defer cancel()
 
-	opts := options.Client().
-		ApplyURI(dsn).
+	opts, err := mongo_fix.ClientForDSN(dsn)
+	if err != nil {
+		panic(err)
+	}
+
+	opts = opts.
 		SetDirect(true).
 		SetReadPreference(readpref.Nearest()).
 		SetSocketTimeout(MgoTimeoutSessionSocket).

--- a/mongo_fix/mongo_fix.go
+++ b/mongo_fix/mongo_fix.go
@@ -1,0 +1,25 @@
+package mongo_fix
+
+import (
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"net/url"
+)
+
+// ClientForDSN applies URI to Client
+func ClientForDSN(dsn string) (*options.ClientOptions, error) {
+	parsedDsn, err := url.Parse(dsn)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot parse DSN")
+	}
+
+	username := parsedDsn.User.Username()
+	password, _ := parsedDsn.User.Password()
+	creds := options.Credential{Username: username, Password: password}
+
+	clientOptions := options.Client().
+		ApplyURI(dsn).
+		SetAuth(creds) //Workaround for PMM-9320
+
+	return clientOptions, nil
+}

--- a/utils/tests/mongodb.go
+++ b/utils/tests/mongodb.go
@@ -17,6 +17,7 @@ package tests
 
 import (
 	"context"
+	"github.com/percona/pmm-agent/mongo_fix"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // GetTestMongoDBDSN returns DNS for MongoDB test database.
@@ -104,7 +104,12 @@ func GetTestMongoDBReplicatedWithSSLDSN(tb testing.TB, pathToRoot string) (strin
 func OpenTestMongoDB(tb testing.TB, dsn string) *mongo.Client {
 	tb.Helper()
 
-	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(dsn))
+	opts, err := mongo_fix.ClientForDSN(dsn)
+	if err != nil {
+		panic(err)
+	}
+
+	client, err := mongo.Connect(context.Background(), opts)
 	require.NoError(tb, err)
 
 	require.NoError(tb, client.Ping(context.Background(), nil))


### PR DESCRIPTION
PMM-9320

Password and Username are escaped According to RFC 3986 §3.2.1

// The RFC allows ';', ':', '&', '=', '+', '$', and ',' in
// userinfo, so we must escape only '@', '/', and '?'.
// The parsing of userinfo treats ':' as special so we must escape
// that too.
go1.18.1/src/net/url/url.go:143

But in MongoDB driver they decided to unscape it as encodePathSegment
using url.PathUnescape
mongo-go-driver/x/mongo/driver/connstring/connstring.go:236 
and
ext/mongo-go-driver/x/mongo/driver/connstring/connstring.go:249
 