### PR TITLE
PMM-9993 Add support to set web.listen-address

### DIFF
--- a/agents/supervisor/supervisor_test.go
+++ b/agents/supervisor/supervisor_test.go
@@ -17,6 +17,7 @@ package supervisor
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -50,7 +51,7 @@ func TestSupervisor(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	tempDir, err := os.MkdirTemp("", "pmm-agent-")
 	require.NoError(t, err)
-	s := NewSupervisor(ctx, &config.Paths{TempDir: tempDir}, &config.Ports{Min: 65000, Max: 65099}, &config.Server{Address: "localhost:443"})
+	s := NewSupervisor(ctx, &config.Paths{TempDir: tempDir}, &config.Ports{Min: 65000, Max: 65099}, &config.Server{Address: "localhost:443"}, &config.ExporterAddress{Default: ""})
 
 	t.Run("Start13", func(t *testing.T) {
 		expectedList := []*agentlocalpb.AgentInfo{}
@@ -284,7 +285,7 @@ func TestSupervisorProcessParams(t *testing.T) {
 			TempDir:        temp,
 		}
 
-		s := NewSupervisor(ctx, paths, &config.Ports{}, &config.Server{}) //nolint:varnamelen
+		s := NewSupervisor(ctx, paths, &config.Ports{}, &config.Server{}, &config.ExporterAddress{Default: "127.0.0.1"}) //nolint:varnamelen
 
 		teardown := func() {
 			cancel()
@@ -326,7 +327,7 @@ func TestSupervisorProcessParams(t *testing.T) {
 		expected := process.Params{
 			Path: "/path/to/mysql_exporter",
 			Args: []string{
-				"-web.listen-address=:12345",
+				fmt.Sprintf("-web.listen-address=%s:12345", s.exporterAddress.ListenAddress()),
 				"-web.ssl-cert-file=" + filepath.Join(s.paths.TempDir, "mysqld_exporter", "ID", "Cert"),
 			},
 			Env: []string{

--- a/commands/run.go
+++ b/commands/run.go
@@ -73,7 +73,7 @@ func run(ctx context.Context, cfg *config.Config, configFilepath string) {
 	// It should be created separately.
 	// TODO https://jira.percona.com/browse/PMM-7206
 
-	supervisor := supervisor.NewSupervisor(ctx, &cfg.Paths, &cfg.Ports, &cfg.Server)
+	supervisor := supervisor.NewSupervisor(ctx, &cfg.Paths, &cfg.Ports, &cfg.Server, &cfg.ExporterListenAddress)
 	connectionChecker := connectionchecker.New(&cfg.Paths)
 	v := versioner.New(&versioner.RealExecFunctions{})
 	client := client.New(cfg, supervisor, connectionChecker, v)

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,16 @@ import (
 
 const pathBaseDefault = "/usr/local/percona/pmm2"
 
+// ExporterAddress stores listen address values for exporters
+type ExporterAddress struct {
+	Default string `yaml:"default"`
+}
+
+// ListenAddress returns the exporter listen-address
+func (e *ExporterAddress) ListenAddress() string {
+	return e.Default
+}
+
 // Server represents PMM Server configuration.
 type Server struct {
 	Address     string `yaml:"address"`
@@ -142,6 +152,8 @@ type Config struct {
 	ID            string `yaml:"id"`
 	ListenAddress string `yaml:"listen-address"`
 	ListenPort    uint16 `yaml:"listen-port"`
+
+	ExporterListenAddress ExporterAddress `yaml:"exporter-listen-address"`
 
 	Server Server `yaml:"server"`
 	Paths  Paths  `yaml:"paths"`
@@ -324,6 +336,8 @@ func Application(cfg *Config) (*kingpin.Application, *string) {
 		Envar("PMM_AGENT_LISTEN_ADDRESS").StringVar(&cfg.ListenAddress)
 	app.Flag("listen-port", "Agent local API port [PMM_AGENT_LISTEN_PORT]").
 		Envar("PMM_AGENT_LISTEN_PORT").Uint16Var(&cfg.ListenPort)
+	app.Flag("exporter-listen-address", "Exporter web interface address [PMM_AGENT_EXPORTER_LISTEN_ADDRESS]").
+		Envar("PMM_AGENT_EXPORTER_LISTEN_ADDRESS").StringVar(&cfg.ExporterListenAddress.Default)
 
 	app.Flag("server-address", "PMM Server address [PMM_AGENT_SERVER_ADDRESS]").
 		Envar("PMM_AGENT_SERVER_ADDRESS").PlaceHolder("<host:port>").StringVar(&cfg.Server.Address)


### PR DESCRIPTION
[PMM-9993](https://jira.percona.com/browse/PMM-9993)

Build: SUBMODULES-0

* Added `--exporter-listen-address` option
* Added `config.ExporterAddress`, stored in the config under
  `exporter-listen-address`
* Added `supervisor.Supervisor.exporterAddress` to refer to
  `config.ExporterAddress`
* Dynamically rewrite any `web.listen-address` that do not have a
  specified address (`=:`)